### PR TITLE
fix: FCM push notifications on real devices

### DIFF
--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"

--- a/code/app/src/main/java/com/first/projectswipe/MainActivity.kt
+++ b/code/app/src/main/java/com/first/projectswipe/MainActivity.kt
@@ -1,15 +1,23 @@
 // MainActivity.kt
 package com.first.projectswipe
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
+import com.first.projectswipe.notifications.FCMTokenManager
 import com.first.projectswipe.presentation.ui.auth.AuthManager
 import com.first.projectswipe.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -56,8 +64,28 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        requestNotificationPermission()
+        syncFcmToken()
+
         // Check authentication status and navigate accordingly
         checkAuthenticationStatus(savedInstanceState)
+    }
+
+    private fun syncFcmToken() {
+        if (authManager.isUserLoggedIn()) {
+            lifecycleScope.launch {
+                FCMTokenManager.getFCMToken()?.let { token -> authManager.registerFcmToken(token) }
+            }
+        }
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.POST_NOTIFICATIONS), 0)
+            }
+        }
     }
 
     private fun checkAuthenticationStatus(savedInstanceState: Bundle?) {

--- a/code/app/src/main/java/com/first/projectswipe/network/NetworkModule.kt
+++ b/code/app/src/main/java/com/first/projectswipe/network/NetworkModule.kt
@@ -41,7 +41,6 @@ class SharedPreferencesTokenProvider @Inject constructor(
 object NetworkModule {
 
     // private const val BASE_URL = "http://10.0.2.2:8080/" // Emulator
-    private const val BASE_URL = "http://localhost:8080/" // Real device via ADB reverse
     // For real device use: "http://YOUR_LOCAL_IP:8080/"
     // For production use: "https://your-backend-domain.com/"
 
@@ -95,7 +94,7 @@ object NetworkModule {
     @Singleton
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(BASE_URL)
+            .baseUrl(RetrofitClient.BASE_URL)
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()

--- a/code/app/src/main/java/com/first/projectswipe/network/RetrofitClient.kt
+++ b/code/app/src/main/java/com/first/projectswipe/network/RetrofitClient.kt
@@ -5,7 +5,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitClient {
 
-    private const val BASE_URL = "http://localhost:8080/"
+    const val BASE_URL = "http://localhost:8080/"
 
     val instance: Retrofit by lazy {
         Retrofit.Builder()

--- a/code/app/src/main/java/com/first/projectswipe/notifications/FCMService.kt
+++ b/code/app/src/main/java/com/first/projectswipe/notifications/FCMService.kt
@@ -110,7 +110,7 @@ class FCMService : FirebaseMessagingService() {
                     )
 
                     val request = okhttp3.Request.Builder()
-                        .url("http://10.0.2.2:8080/api/notifications/register-token") // Update if needed
+                        .url(com.first.projectswipe.network.RetrofitClient.BASE_URL + "api/notifications/register-token")
                         .post(body)
                         .addHeader("Authorization", "Bearer $jwtToken")
                         .addHeader("Content-Type", "application/json")

--- a/code/app/src/main/java/com/first/projectswipe/presentation/ui/auth/AuthManager.kt
+++ b/code/app/src/main/java/com/first/projectswipe/presentation/ui/auth/AuthManager.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.MutableLiveData
 import com.first.projectswipe.data.models.User
 import com.first.projectswipe.network.ApiService
 import com.first.projectswipe.network.dto.*
+import com.first.projectswipe.notifications.FCMTokenManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Response
@@ -79,6 +80,8 @@ class AuthManager @Inject constructor(
                     val authResponse = response.body()!!
                     saveUserSession(authResponse)
 
+                    FCMTokenManager.getFCMToken()?.let { fcmToken -> registerFcmToken(fcmToken) }
+
                     withContext(Dispatchers.Main) {
                         _isLoggedIn.value = true
                         _authState.value = AuthState.Success(getCurrentUser()!!)
@@ -125,6 +128,8 @@ class AuthManager @Inject constructor(
                 if (response.isSuccessful && response.body() != null) {
                     val authResponse = response.body()!!
                     saveUserSession(authResponse)
+
+                    FCMTokenManager.getFCMToken()?.let { fcmToken -> registerFcmToken(fcmToken) }
 
                     withContext(Dispatchers.Main) {
                         _isLoggedIn.value = true


### PR DESCRIPTION
## 📋 Pull Request Description

### What does this PR do?
Fixes push notifications being silently broken on physical devices. Three separate issues were causing this — a hardcoded emulator URL, FCM token never being registered on login/app launch, and a missing Android 13+ notification permission.

### Related Issues
- Fixes #81

## 📱 Platform(s) Affected
- [x] Android
- [x] Backend/API
- [ ] Web Interface
- [ ] Documentation
- [ ] CI/CD

## 🧪 Type of Changes
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 📝 Detailed Changes

### Key Changes Made:
- **`FCMService.kt`** — replaced hardcoded `10.0.2.2:8080` emulator address with `RetrofitClient.BASE_URL` so the token registration request reaches the backend on real devices
- **`RetrofitClient.kt`** — exposed `BASE_URL` as a public constant so it can be shared across the codebase
- **`NetworkModule.kt`** — removed duplicate `BASE_URL` constant, now references `RetrofitClient.BASE_URL` as the single source of truth
- **`AuthManager.kt`** — added FCM token registration after every successful login, so returning users don't need to reinstall to get notifications
- **`MainActivity.kt`** — added `syncFcmToken()` on app launch (covers new registrations and token refreshes) and added runtime `POST_NOTIFICATIONS` permission request for Android 13+
- **`AndroidManifest.xml`** — added `POST_NOTIFICATIONS` permission declaration required for Android 13+

### Technical Details:
`FCMService.onNewToken` only fires on first install or forced token refresh — it never fires for returning users. The fix ensures the current FCM token is registered every time the user logs in and every time the app launches while already authenticated.

## 🧪 Testing
### How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Automated UI tests

### Test Cases Covered:
- [x] Fresh registration → FCM token appears in DB without logging out
- [x] Login on real device → FCM token registered
- [x] Firebase Console test message → notification received on device
- [x] Real chat message sent between two users (emulator + real device) → push notification delivered

## 📷 Screenshots/Videos

### After:
Notifications working end-to-end between emulator and physical device via Firebase Cloud Messaging.

## 📊 Performance Impact
- [x] No performance impact

## 🔐 Security Considerations
- [x] No security implications

## 📋 Migration Notes
- [x] No migration required

## ✅ Checklist
### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added error handling where appropriate

### Testing
- [x] I have tested this change on multiple devices (emulator + physical device)

### Dependencies
- [x] I have not introduced any new dependencies without discussion